### PR TITLE
Fixed name of pip.util for Ubuntu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # {{pkglts github,
-*.py[cod]
+*.py[cod~]
 
 # Packages
 *.egg

--- a/src/pkglts/manage_tools.py
+++ b/src/pkglts/manage_tools.py
@@ -29,7 +29,7 @@ def ensure_installed_packages(requirements, msg):
      - requirements (list of str): list of package names to pip install
                                    if needed
     """
-    pip.utils.pkg_resources = imp.reload(pip.utils.pkg_resources)
+    pip.util.pkg_resources = imp.reload(pip.util.pkg_resources)
     installed = set(p.project_name for p in get_installed_distributions())
     to_install = set(requirements) - installed
     if len(to_install) > 0:


### PR DESCRIPTION
"pmg add base" does not work with the current package name (pip.utils) on Ubuntu, because the name is wrong. Other platforms need to be checked.

Also added *.py~ to the list of extensions to ignore in .gitignore