### PR TITLE
Add coverage option

### DIFF
--- a/.pkglts/pkg_cfg.json
+++ b/.pkglts/pkg_cfg.json
@@ -21,7 +21,13 @@
     "url": null
   },
   "conda": {},
-  "coverage": {},
+  "coverage": {
+    "exclude_lines": [
+      "raise AssertionError",
+      "raise NotImplemented",
+      "raise NotImplementedError"
+      ]
+  },
   "coveralls": {},
   "data": {
     "filetype": [
@@ -124,7 +130,7 @@
   "travis": {},
   "version": {
     "major": 3,
-    "minor": 3,
+    "minor": 4,
     "post": 1
   }
 }

--- a/.pkglts/pkg_hash.json
+++ b/.pkglts/pkg_hash.json
@@ -40,7 +40,7 @@
   },
   "conda/meta.yaml": {
     "conda.about": "7jgIubwtZ5uu8wIoAJBjSpwLdOSRdmKwx0EYKW1u0AW5g9QBTWSIUvuADIkyH9j4uiSjDC0TYhWczajS11WuoQ==",
-    "conda.package": "CWDtvm4WxdSrgEk/FXk/fzstSDWQvU5bhXzvbZpMO29iB+Y1S6Ni8c9evLU8X9uTuh/G7wPJ+wE/iN+dEzgOaQ==",
+    "conda.package": "RY/hgbFuM06xZpZmucgWNgCHq3xfLFfnAVtBmFVb2xxTF8wqvarPoV8maw2z3BIFqdqLGoEERteIj3BjkO5Hwg==",
     "conda.req_build": "sTGn3R/3JQrBzHUPc05zAOCoaG/3bk/2XxDXuB2yLzi5ZYJQyHbI7BpllnugDeu9Q4PgvKakGXlZU05Pv7mggQ==",
     "conda.req_run": "wfQxh4h17xfUYLjddGfAUGaFHpJYO0q2BvR1VlOGOvWA3cWupGDbJu67jP/uth9U6E4LgB0zwW7LsIclj93wHg==",
     "conda.src": "HrwSleFu4NbgkAAkAfKBpsU5jaVQ83sYumDl1fUALX04VYq8s0OexqOusF2UQ/BxfHXQWGQEQ/0OBDbmkNE0Aw=="
@@ -82,7 +82,7 @@
   },
   "setup.py": {
     "pysetup.call": "2wHuP94SpWKZpqOzExkQGTxnhGPgBHK3qOdPn0Ncstj5FkZ7FBGGM/inqAXaI4QLKQtTNlOUYRGSkYUWAUcf1w==",
-    "pysetup.kwds": "fq33mB44lWeNwTzfDFlRq+wwKCvCXUhgl2My6gfuz6Q5MuhwuLQLMAxYznwAfSQ52miQhizYxsqRENM54S0ZNw=="
+    "pysetup.kwds": "NH04jxER7AyAAEw6h4Ge/GIV9+1YabUNIHQtTIag/Z7jYED45gCqwNDYIfW9b2VOcy6RQs3W+zvO9iTjpVHLSQ=="
   },
   "src/pkglts/__init__.py": {
     "base": "gR33dW0qqYmsV9NSNB+DD8XmuxnC2t0mKjnMoU5728qh97fSER6MbX+3QKxpZDLByZToaAay4xhx8acxketJmA=="
@@ -91,7 +91,7 @@
     "data": "wwgLuV/OqHWjWbssvDHa4LNg+7C+tuNiKHOxkO+9UAl9opI/HfPyJAq2fPhUeTmVvb/E6MkqDJIli9m8n5/V0Q=="
   },
   "src/pkglts/version.py": {
-    "version": "z/+H9d6+SKoyGvMLEvHOsmY2lT7x27sNvfM4y4Tl9F88Zq6KzvXjI1roYlzux1Au0h5175xQhmf3z4sCvlTf4Q=="
+    "version": "HfpjmKWbQNNRymWFcWRiylZrjw/JaxlK/sKYFqQOdh2kZ398agTKCzdZZg5J5v0rV8jNBIUC3XuJ7Ei542oc7g=="
   },
   "src/pkglts_data/__init__.py": {},
   "test/__init__.py": {},

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,7 +1,7 @@
 # {# pkglts, conda.package
 package:
   name: pkglts
-  version: "3.3.1"
+  version: "3.4.1"
 # #}
 
 # {# pkglts, conda.src

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ pkg_data['pkglts'] = data_files
 
 setup_kwds = dict(
     name='pkglts',
-    version="3.3.1",
+    version="3.4.1",
     description=short_descr,
     long_description=readme + '\n\n' + history,
     author="revesansparole",

--- a/src/pkglts/option/coverage/option.py
+++ b/src/pkglts/option/coverage/option.py
@@ -2,11 +2,22 @@ from os.path import dirname
 
 from pkglts.dependency import Dependency
 from pkglts.option_object import Option
+from pkglts.option.pysetup.option import requirements
 
 
 class OptionCoverage(Option):
     def root_dir(self):
         return dirname(__file__)
+
+    def update_parameters(self, cfg):
+        sec = dict(
+            exclude_lines=[
+                "raise AssertionError",
+                "raise NotImplemented",
+                "raise NotImplementedError"
+            ],
+        )
+        cfg['coverage'] = sec
 
     def require(self, purpose, cfg):
         if purpose == 'option':
@@ -22,3 +33,10 @@ class OptionCoverage(Option):
             return deps
 
         return []
+
+    def environment_extensions(self, cfg):
+        if 'exclude_lines' in cfg['coverage'].keys():
+            exclude_lines = cfg['coverage']['exclude_lines']
+        else:
+            exclude_lines = []
+        return {"exclude_lines": exclude_lines}

--- a/src/pkglts/option/coverage/resource/.coveragerc
+++ b/src/pkglts/option/coverage/resource/.coveragerc
@@ -9,9 +9,9 @@ source = {{ base.pkg_full_name }}
 [report]
 exclude_lines =
     # Don't complain if tests don't hit defensive assertion code:
-    raise AssertionError
-    raise NotImplemented
-    raise NotImplementedError
+    {%- for exclude_line in coverage.exclude_lines %}
+    {{ exclude_line }}
+    {%- endfor %}
 show_missing = True
 
 # #}

--- a/src/pkglts/version.py
+++ b/src/pkglts/version.py
@@ -7,7 +7,7 @@ Maintain version for this package.
 MAJOR = 3
 """(int) Version major component."""
 
-MINOR = 3
+MINOR = 4
 """(int) Version minor component."""
 
 POST = 1

--- a/test/test_option/test_coverage/test_handlers.py
+++ b/test/test_option/test_coverage/test_handlers.py
@@ -1,0 +1,14 @@
+from pkglts.config_management import Config
+
+
+def test_exclude_lines_no_empty():
+    exclude_lines = ['a', 'b']
+    cfg = Config(dict(coverage={'exclude_lines': exclude_lines}))
+    cfg.load_extra()
+    assert cfg._env.globals['coverage'].exclude_lines == exclude_lines
+
+
+def test_exclude_lines_empty():
+    cfg = Config(dict(coverage={}))
+    cfg.load_extra()
+    assert cfg._env.globals['coverage'].exclude_lines == []


### PR DESCRIPTION
To use this version of pkglts without any change in coverage you have to add manually
```
"exclude_lines": [
"raise AssertionError",
"raise NotImplemented",
"raise NotImplementedError"
 ]
```
in coverage option.
I don't know if we should make a new input version to avoid that or not ?