### PR TITLE
Import FileNotFoundError for Python2 compatibility

### DIFF
--- a/src/pkglts/manage_script.py
+++ b/src/pkglts/manage_script.py
@@ -9,7 +9,8 @@ from . import logging_tools
 from .config_management import get_pkg_config, write_pkg_config
 from .manage import add_option, clean, init_pkg, install_example_files, regenerate_option, regenerate_package
 from .option_tools import available_options
-from .version_management import outdated_options, write_pkg_version
+from .version_management import outdated_options, write_pkg_version, FileNotFoundError
+
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
On Python 2, I have an error when running 
 `   pmg -h `
This is because _FileNotFoundError_ is only defined in Python 3.
Just import it from version_management which has already implement a fix.